### PR TITLE
Add video resolution capture to FaceLandmark calibration

### DIFF
--- a/source/application/Components/Questions/FaceLandmarkCalibration/FaceLandmarkCalibration.ts
+++ b/source/application/Components/Questions/FaceLandmarkCalibration/FaceLandmarkCalibration.ts
@@ -94,6 +94,8 @@ interface CalibrationPoint {
 
 type Calibration = {
   calibrationPoints: CalibrationPoint;
+  videoWidth?: number;
+  videoHeight?: number;
 };
 
 enum CALIBRATION_STATE {
@@ -467,7 +469,11 @@ class FaceLandmarkCalibration extends QuestionBase<Calibration> {
 
     this.CanAnswer(true);
 
-    this.Answer({ calibrationPoints: this.CalibrationPoints });
+    this.Answer({
+      calibrationPoints: this.CalibrationPoints,
+      videoWidth: getFaceLandmarkerManager().videoWidth,
+      videoHeight: getFaceLandmarkerManager().videoHeight,
+    });
 
     this.showSlideShellNavigationElements();
 

--- a/source/application/Components/Questions/FaceLandmarkCalibration/FaceLandmarkCalibrationPage.ts
+++ b/source/application/Components/Questions/FaceLandmarkCalibration/FaceLandmarkCalibrationPage.ts
@@ -70,13 +70,17 @@ export class FaceLandmarkCalibrationPage {
         const videoTrack = stream.getVideoTracks()[0];
         const settings = videoTrack.getSettings();
         const frameRate = settings.frameRate;
+        const actualWidth = settings.width;
+        const actualHeight = settings.height;
 
         try {
           if (this.calibrationVideoEl) {
             const ratio = await this.configureCalibrationVideoElement(stream);
             getFaceLandmarkerManager().videoAspectRatio = ratio;
             getFaceLandmarkerManager().webcamFrameRate = frameRate;
-            console.log(`navigator.mediaDevices.getUserMedia: ratio:${ratio} framerate:${frameRate}`);
+            getFaceLandmarkerManager().videoWidth = actualWidth;
+            getFaceLandmarkerManager().videoHeight = actualHeight;
+            console.log(`navigator.mediaDevices.getUserMedia: ratio:${ratio} framerate:${frameRate} resolution:${actualWidth}x${actualHeight}`);
           }
           await this.configureMonitorVideoElement(stream);
           this.ShowCalibrationPoint();

--- a/source/application/Managers/FaceLandmarkerManager.ts
+++ b/source/application/Managers/FaceLandmarkerManager.ts
@@ -97,6 +97,8 @@ class FaceLandmarkerManager extends DisposableComponent {
 
   public videoAspectRatio: number | null = null;
   public webcamFrameRate: number | null = null;
+  public videoWidth: number | null = null;
+  public videoHeight: number | null = null;
   private landmarkerMonitorViewModel: FaceLandmarkStatsMonitor;
   private debugMode = false;
 
@@ -299,6 +301,8 @@ class FaceLandmarkerManager extends DisposableComponent {
           video_aspect_ratio: this.videoAspectRatio,
           webcam_frame_rate: this.webcamFrameRate,
           clock_skew_ms: differenceMs,
+          video_width: this.videoWidth,
+          video_height: this.videoHeight,
         }
       : {};
     const dataPoint = {


### PR DESCRIPTION
## Summary
Add capture of actual video resolution from webcam during FaceLandmark calibration process. The resolution is now stored and included in both the lifecycle start event and the calibration answer payload.

## Changes
- **FaceLandmarkerManager.ts**: Added `videoWidth` and `videoHeight` properties to store the actual camera resolution
- **FaceLandmarkCalibrationPage.ts**: Capture actual resolution from `videoTrack.getSettings()` when initializing the webcam stream
- **FaceLandmarkCalibration.ts**: Include resolution in the calibration answer sent to the backend

## Technical Details
The resolution is captured from `MediaStreamTrack.getSettings()` which returns the actual camera resolution (not the requested ideal). This is more accurate than the aspect ratio alone and provides exact dimensions for analysis.

The resolution flows through:
1. Webcam initialization → `FaceLandmarkerManager.videoWidth/Height`
2. Lifecycle start event → `video_width` and `video_height` in config
3. Calibration completion → Included in answer payload

## Testing
- Tested with various webcam resolutions
- Resolution correctly captured and included in data payloads
- Backwards compatible - existing calibration flows continue to work