### PR TITLE
Fix race condition causing completed_at to not be set

### DIFF
--- a/source/application/Managers/Portal/Experiment.ts
+++ b/source/application/Managers/Portal/Experiment.ts
@@ -78,13 +78,12 @@ class Experiment extends DisposableComponent {
   }
 
   public ExperimentCompleted(): void {
-    Portal.AllowPageLoads();
-
     Slide.Completed(this._id, this.NumberOfSlides() - 1).WithCallback((response) => {
       if (response.Error != null) Notification.Error(`Failed to complete experiment: ${response.Error.Message}`);
-    });
 
-    this.IsExperimentCompleted(true);
+      Portal.AllowPageLoads();
+      this.IsExperimentCompleted(true);
+    });
   }
 
   public Load(id: string): void {


### PR DESCRIPTION
Fixes a bug where completed_at was not being set for completed experiments.

## Problem
The <code>ExperimentCompleted()</code> method had a race condition:
1. <code>Portal.AllowPageLoads()</code> removed the beforeunload protection immediately
2. <code>Slide.Completed()</code> API call was fired asynchronously  
3. <code>IsExperimentCompleted(true)</code> made the Close button visible immediately
4. User could click Close and navigate away before the API call completed
5. The <code>Slide/Completed</code> request would be cancelled, leaving <code>completed_at</code> unset

## Solution
Move <code>Portal.AllowPageLoads()</code> and <code>IsExperimentCompleted(true)</code> inside the <code>WithCallback</code> closure so they only execute after the API call completes (success or error). This ensures:
- The <code>beforeunload</code> protection stays active during the API call
- Users can only close the experiment after the backend has recorded completion
- The callback is always invoked (finally semantics per PortalClient implementation)

## Testing
- Verify that completing an experiment still works correctly
- Check that completed_at is now properly set in the database
- Confirm error handling still works if the API call fails